### PR TITLE
Update Gradle wrapper to 8.1 and modernize build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'com.example.payment'
@@ -74,7 +74,6 @@ application {
 shadowJar {
     archiveBaseName = 'payment-processing-service'
     archiveVersion = version
-    mainClassName = 'PaymentApplication'
     mergeServiceFiles()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Updated Gradle wrapper from 6.9 to 8.1 for improved build performance and modern features
- Updated Shadow plugin from 6.1.0 to 8.1.1 for better compatibility with Gradle 8.1
- Modernized build configuration and removed deprecated mainClassName property
- Enhanced build toolchain with latest Gradle capabilities

## Test plan
- Verify build works correctly with new Gradle version
- Test shadow jar generation with updated plugin
- Ensure all gradle tasks execute successfully
- Validate application packaging and deployment

🤖 Generated with [Claude Code](https://claude.ai/code)